### PR TITLE
Fixed puppet not applying if the pack modified in puppet master

### DIFF
--- a/manifests/clean_deployment.pp
+++ b/manifests/clean_deployment.pp
@@ -1,0 +1,44 @@
+#----------------------------------------------------------------------------
+#  Copyright (c) 2016 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+# check the pack against the latest pack in the puppet master and do cleanup if necessary 
+define wso2base::clean_deployment ($pack_file_abs_path, $caller_module_name, $pack_filename, $user, $group, $install_dir, $pack_dir) {
+    $temp_pack_file_abs_path = "/tmp/${pack_filename}"
+    $install_dirs = [ $install_dir, $pack_dir ]
+
+    # download the current pack exists in the puppet master to temporary location
+    file { "${temp_pack_file_abs_path}":
+        ensure         => file,
+        source         => ["puppet:///modules/${caller_module_name}/${pack_filename}", "puppet:///files/packs/${pack_filename}"],
+        replace        => true,
+        notify         => Exec['check_diff']
+    }
+
+    # if there is a difference between the current pack and the new pack, remove the current pack and the deploymentn
+    exec { 'check_diff':
+        command        => "rm -rf ${install_dir}/* ${pack_dir}/*",
+        path           => ['/usr/bin', '/usr/sbin', '/bin'],
+        onlyif         => "test `diff -q ${pack_file_abs_path} ${temp_pack_file_abs_path} >/dev/null; echo $?` -eq 1",
+        notify         => Exec['clean_temp_pack']
+    }
+
+    # remove the temporary packs
+    exec { 'clean_temp_pack':
+        command        => "rm ${temp_pack_file_abs_path}",
+        path           => ['/usr/bin', '/usr/sbin', '/bin'],
+        onlyif         => "test -f ${temp_pack_file_abs_path}"
+    }
+}


### PR DESCRIPTION
When running puppet after initial deployment, this fix checks the product pack in the current deployment against the pack at the puppet master and redeploys if the pack has been modified at the puppet master side.