### PR TITLE
Fix Java installation flow

### DIFF
--- a/hieradata/dev/wso2/common.yaml
+++ b/hieradata/dev/wso2/common.yaml
@@ -213,10 +213,6 @@ wso2::user_management:
   admin_username: "%{hiera('wso2::super_admin::username')}"
   admin_password: "%{hiera('wso2::super_admin::password')}"
 
-# class responsible for installing Java
-# Plugin any 3rd party class here as you wish
-java_class: wso2base::java
-
 # symlink to Java install directory
 java_home: /opt/java
 
@@ -225,11 +221,12 @@ java_prefs_system_root: "/home/%{hiera('wso2::user')}/.java"
 java_prefs_user_root: "/home/%{hiera('wso2::user')}/.java/.systemPrefs"
 
 # wso2base::java class automatic parameter lookup
-wso2base::java::java_install_dir: /mnt/jdk-8u112
-wso2base::java::java_source_file: jdk-8u112-linux-x64.tar.gz
+wso2base::java::install_java: true
+wso2base::java::java_install_dir: /mnt/jdk-8u131
+wso2base::java::java_source_file: jdk-8u131-linux-x64.tar.gz
 wso2base::java::wso2_user: "%{hiera('wso2::user')}"
 wso2base::java::wso2_group: "%{hiera('wso2::group')}"
-wso2base::java::java_home: /opt/java
+wso2base::java::java_home: "%{hiera('java_home')}"
 wso2base::java::prefs_system_root: "%{hiera('java_prefs_system_root')}"
 wso2base::java::prefs_user_root: "%{hiera('java_prefs_user_root')}"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,11 @@ class wso2base (
   $system_file_list,
   $directory_list,
   $hosts_mapping,
+  $install_java,
+  $java_install_dir,
+  $java_source_file,
+  $java_user,
+  $java_group,
   $java_home,
   $java_prefs_system_root,
   $java_prefs_user_root,
@@ -76,6 +81,11 @@ class wso2base (
     validate_array($directory_list)
   }
   validate_hash($hosts_mapping)
+  validate_bool($install_java)
+  validate_string($java_install_dir)
+  validate_string($java_source_file)
+  validate_string($java_user)
+  validate_string($java_group)
   validate_string($java_home)
   validate_string($java_prefs_system_root)
   validate_string($java_prefs_user_root)

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -15,16 +15,7 @@
 #----------------------------------------------------------------------------
 #
 # Class to manage Java installation
-class wso2base::java (
-  $deploymentdir     = '/mnt/jdk-8u112',
-  $source            = 'jdk-8u112-linux-x64.tar.gz',
-  $java_home         = '/opt/java',
-  $user              = 'root',
-  $cachedir          = '/opt/java-setup',
-  $ensure            = 'present',
-  $remove_cachedir   = false,
-  $pathfile          = '/etc/bashrc'
-) {
+define wso2base::java ($deploymentdir, $source, $java_home, $user, $group) {
 
   case $::osfamily {
     'Debian'  : { $supported = true }
@@ -36,17 +27,13 @@ class wso2base::java (
   # Validate parameters
   validate_string($source)
   validate_string($user)
-  validate_string($ensure)
-  validate_bool($remove_cachedir)
+  validate_string($group)
+  validate_string($deploymentdir)
+  validate_string($java_home)
 
   # Validate source is .gz or .tar.gz
   if !(('.tar.gz' in $source) or ('.gz' in $source) or ('.bin' in $source)) {
     fail('source must be either .tar.gz or .gz or .bin')
-  }
-
-  # Validate input values for $ensure
-  if !($ensure in ['present', 'absent']) {
-    fail('ensure must either be present or absent')
   }
 
   if ($caller_module_name == undef) {
@@ -60,110 +47,84 @@ class wso2base::java (
     path => ['/sbin', '/bin', '/usr/sbin', '/usr/bin'],
   }
 
-  # Install java only when ensure => present
-  if ($ensure == 'present') {
+  $install_dirs = [$deploymentdir, '/opt/java-setup']
+  ensure_resource('file', $install_dirs, {
+    ensure  => 'directory'
+  })
 
-    $install_dirs = [$deploymentdir, $cachedir]
-    ensure_resource('file', $install_dirs, {
-      ensure  => 'directory'
-    })
+  file { "/opt/java-setup/${source}":
+    source  => [
+      "puppet:///modules/${mod_name}/${source}",
+      "puppet:///files/packs/${source}"
+    ],
+    mode    => '0711',
+    require => File[$install_dirs],
+  }
 
-    file { "${cachedir}/${source}":
-      source  => [
-        "puppet:///modules/${mod_name}/${source}",
-        "puppet:///files/packs/${source}"
-      ],
-      mode    => '0711',
-      require => File[$install_dirs],
+  if ('.bin' in $source) {
+    exec { "extract_java-${name}":
+      cwd     => '/opt/java-setup',
+      command => "mkdir extracted; cd extracted ;  ../*.bin  <> echo '\n\n' -d extracted && touch /opt/java-setup/.java_extracted",
+      creates => "/opt/java-setup/.java_extracted",
+      # in case of a bin archive, we get a return code of 1 from unzip. This is ok
+      returns => [0, 1],
+      require => File["/opt/java-setup/${source}"],
     }
-
-    if ('.bin' in $source) {
-      exec { "extract_java-${name}":
-        cwd     => $cachedir,
-        command => "mkdir extracted; cd extracted ;  ../*.bin  <> echo '\n\n' -d extracted && touch ${cachedir}/.java_extracted",
-        creates => "${cachedir}/.java_extracted",
-        # in case of a bin archive, we get a return code of 1 from unzip. This is ok
-        returns => [0, 1],
-        require => File["${cachedir}/${source}"],
-      }
-    } else {
-      exec { "extract_java-${name}":
-        cwd     => $cachedir,
-        command => "mkdir extracted; tar -C extracted -xzf *.gz && touch ${cachedir}/.java_extracted",
-        creates => "${cachedir}/.java_extracted",
-        require => File["${cachedir}/${source}"],
-      }
-    }
-
-    exec { "create_target-${name}":
-      cwd     => '/',
-      command => "mkdir -p ${deploymentdir}",
-      creates => $deploymentdir,
-      require => Exec["extract_java-${name}"],
-    }
-
-    exec { "move_java-${name}":
-      cwd     => "${cachedir}/extracted",
-      command => "cp -r */* ${deploymentdir}/ && chown -R ${user}:${user} ${deploymentdir} && touch ${deploymentdir}/.puppet_java_${name}_deployed",
-      creates => "${deploymentdir}/.puppet_java_${name}_deployed",
-      require => Exec["create_target-${name}"],
-    }
-
-    exec { "set_java_home-${name}":
-      cwd     => '/',
-      command => "echo 'export JAVA_HOME=${deploymentdir}' >> ${pathfile}",
-      unless  => "grep 'JAVA_HOME=${deploymentdir}' ${pathfile}",
-      require => Exec["move_java-${name}"],
-    }
-
-    exec { "update_path-${name}":
-      cwd     => '/',
-      command => "echo 'export PATH=\$JAVA_HOME/bin:\$PATH' >> ${pathfile}",
-      unless  => "grep 'export PATH=\$JAVA_HOME/bin:\$PATH' ${pathfile}",
-      require => Exec["set_java_home-${name}"],
-    }
-
-    exec { "update_classpath-${name}":
-      cwd     => '/',
-      command => "echo 'export CLASSPATH=\$JAVA_HOME/lib/classes.zip' >> ${pathfile}",
-      unless  => "grep 'export CLASSPATH=\$JAVA_HOME/lib/classes.zip' ${pathfile}",
-      require => Exec["set_java_home-${name}"],
-    }
-
-    # create a symlink for Java deployment
-    file { $java_home:
-      ensure  => 'link',
-      target  => $deploymentdir,
-      require => Exec["update_classpath-${name}"]
-    }
-
-    # set JAVA_HOME environment variable and include JAVA_HOME/bin in PATH for all users
-    file { '/etc/profile.d/set_java_home.sh':
-      ensure  => present,
-      content => inline_template("JAVA_HOME=${java_home}\nPATH=${java_home}/bin:\$PATH"),
-      require => File[$java_home]
-    }
-
-    if $remove_cachedir {
-      file { $cachedir:
-        ensure  => absent,
-        recurse => true,
-        force   => true,
-        require => Exec["move_java-${name}"]
-      }
-    }
-
   } else {
-    file { $deploymentdir:
-      ensure  => absent,
-      recurse => true,
-      force   => true,
+    exec { "extract_java-${name}":
+      cwd     => '/opt/java-setup',
+      command => "mkdir extracted; tar -C extracted -xzf *.gz && touch /opt/java-setup/.java_extracted",
+      creates => "/opt/java-setup/.java_extracted",
+      require => File["/opt/java-setup/${source}"],
     }
+  }
 
-    file { $cachedir:
-      ensure  => absent,
-      recurse => true,
-      force   => true,
-    }
+  exec { "create_target-${name}":
+    cwd     => '/',
+    command => "mkdir -p ${deploymentdir}",
+    creates => $deploymentdir,
+    require => Exec["extract_java-${name}"],
+  }
+
+  exec { "move_java-${name}":
+    cwd     => "/opt/java-setup/extracted",
+    command => "cp -r */* ${deploymentdir}/ && chown -R ${user}:${group} ${deploymentdir} && touch ${deploymentdir}/.puppet_java_${name}_deployed",
+    creates => "${deploymentdir}/.puppet_java_${name}_deployed",
+    require => Exec["create_target-${name}"],
+  }
+
+  exec { "set_java_home-${name}":
+    cwd     => '/',
+    command => "echo 'export JAVA_HOME=${java_home}' >> /etc/.bashrc",
+    unless  => "grep 'JAVA_HOME=${java_home}' /etc/.bashrc",
+    require => Exec["move_java-${name}"],
+  }
+
+  exec { "update_path-${name}":
+    cwd     => '/',
+    command => "echo 'export PATH=\$JAVA_HOME/bin:\$PATH' >> /etc/.bashrc",
+    unless  => "grep 'export PATH=\$JAVA_HOME/bin:\$PATH' /etc/.bashrc",
+    require => Exec["set_java_home-${name}"],
+  }
+
+  exec { "update_classpath-${name}":
+    cwd     => '/',
+    command => "echo 'export CLASSPATH=\$JAVA_HOME/lib/classes.zip' >> /etc/.bashrc",
+    unless  => "grep 'export CLASSPATH=\$JAVA_HOME/lib/classes.zip' /etc/.bashrc",
+    require => Exec["set_java_home-${name}"],
+  }
+
+  # create a symlink for Java deployment
+  file { $java_home:
+    ensure  => 'link',
+    target  => $deploymentdir,
+    require => Exec["update_classpath-${name}"]
+  }
+
+  # set JAVA_HOME environment variable and include JAVA_HOME/bin in PATH for all users
+  file { '/etc/profile.d/set_java_home.sh':
+    ensure  => present,
+    content => inline_template("JAVA_HOME=${java_home}\nPATH=${java_home}/bin:\$PATH"),
+    require => File[$java_home]
   }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -72,7 +72,7 @@ class wso2base::system {
   }
 
   # Install JDK only if install_java is set to true
-  if ($install_java == 'true') {
+  if ($install_java) {
     # Set Java system preferences directory
     file{ [$java_prefs_system_root, $java_prefs_user_root]:
       ensure  => 'directory',

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -24,6 +24,12 @@ class wso2base::system {
   $service_name           = $wso2base::service_name
   $service_template       = $wso2base::service_template
   $hosts_mapping          = $wso2base::hosts_mapping
+  $install_java           = $wso2base::install_java
+  $java_install_dir       = $wso2base::java_install_dir
+  $java_source_file       = $wso2base::java_source_file
+  $java_user              = $wso2base::java_user
+  $java_group             = $wso2base::java_group
+  $java_home              = $wso2base::java_home
   $java_prefs_system_root = $wso2base::java_prefs_system_root
   $java_prefs_user_root   = $wso2base::java_prefs_user_root
 
@@ -65,12 +71,24 @@ class wso2base::system {
     }
   }
 
-  # Set Java system preferences directory
-  file{ [$java_prefs_system_root, $java_prefs_user_root]:
-    ensure  => 'directory',
-    owner   => $wso2_user,
-    group   => $wso2_group,
-    mode    => '0755',
-    require => [Group[$wso2_group], User[$wso2_user]]
+  # Install JDK only if install_java is set to true
+  if ($install_java == 'true') {
+    # Set Java system preferences directory
+    file{ [$java_prefs_system_root, $java_prefs_user_root]:
+      ensure  => 'directory',
+      owner   => $wso2_user,
+      group   => $wso2_group,
+      mode    => '0755',
+      require => [Group[$wso2_group], User[$wso2_user]]
+    }
+
+    wso2base::java {
+      'jdk_installation':
+        deploymentdir => $java_install_dir,
+        source        => $java_source_file,
+        java_home     => $java_home,
+        user          => $java_user,
+        group         => $java_group
+    }
   }
 }


### PR DESCRIPTION
This PR changes the Java manifest in the base module from a Puppet class to a Puppet defined type. This avoids having hard coded values as before and allows them to be passed from the caller manifest.

Furthermore, it also introduces and new Hieradata key to control the JDK installation.

```yaml
wso2base::java::install_java: true
```
Setting this to `false` will result in JDK not being added by Puppet. The default value is `true` set in the `wso2/common` Hiera file. 

> NOTE: For these changes to work, https://github.com/wso2/puppet-common/pull/13 in wso2/puppet-common should also be merged. 

This resolves #16 and #18. 