### PR TITLE
Contorl starting the WSO2 service automatically through Hiera

### DIFF
--- a/hieradata/dev/wso2/common.yaml
+++ b/hieradata/dev/wso2/common.yaml
@@ -36,6 +36,9 @@ wso2::fqdn: "%{::fqdn}"
 # System service name
 wso2::service_template: wso2base/wso2service.erb
 
+# Start WSO2 Server Service automatically
+wso2::autostart_service: true
+
 # Puppet template list to be populated
 wso2::template_list:
   - repository/conf/carbon.xml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class wso2base (
   $patches_dir,
   $service_name,
   $service_template,
+  $autostart_service,
   $ipaddress,
   $enable_secure_vault,
   $secure_vault_configs,
@@ -105,6 +106,7 @@ class wso2base (
   validate_string($patches_dir)
   validate_string($service_name)
   validate_string($service_template)
+  validate_bool($autostart_service)
   validate_string($ipaddress)
   validate_bool($enable_secure_vault)
   validate_hash($key_stores)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,14 +16,15 @@
 
 class wso2base::service {
 
-  $vm_type      = $wso2base::vm_type
-  $service_name = $wso2base::service_name
-  $install_dir  = $wso2base::install_dir
-  $carbon_home  = $wso2base::carbon_home
+  $vm_type           = $wso2base::vm_type
+  $service_name      = $wso2base::service_name
+  $install_dir       = $wso2base::install_dir
+  $carbon_home       = $wso2base::carbon_home
+  $autostart_service = $wso2base::autostart_service
 
   # Start the service
   # TODO: start the service only if configuration changes are applied that needs a restart to be effective
-  if $vm_type != 'docker' {
+  if ($vm_type != 'docker') and ($autostart_service) {
     service { $service_name:
       ensure     => running,
       hasstatus  => true,


### PR DESCRIPTION
This PR introduces a new Hiera key that can be set to `true` or `false` that will control the flow in Puppet where the created WSO2 service is automatically started.

The product module should read this value from Hiera (or through Puppet variables if Hiera is not used) and pass the value to `autostart_service` variable in the `wso2base` module.

```yaml
wso2::autostart_service: true
```
