### PR TITLE
Remove validation for secure_vault_configs

### DIFF
--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -23,8 +23,6 @@ class wso2base::configure {
   $patch_list           = $wso2base::patch_list
   $cert_list            = $wso2base::cert_list
   $system_file_list     = $wso2base::system_file_list
-  $secure_vault_configs = $wso2base::secure_vault_configs
-  $enable_secure_vault  = $wso2base::enable_secure_vault
   $carbon_home          = $wso2base::carbon_home
   $wso2_group           = $wso2base::wso2_group
   $wso2_user            = $wso2base::wso2_user

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,8 +102,4 @@ class wso2base (
   if $install_mode == 'file_repo' {
     validate_string($remote_file_url)
   }
-
-  if $enable_secure_vault {
-    validate_hash($secure_vault_configs)
-  }
 }


### PR DESCRIPTION
This PR removes the validation for `secure_vault_configs` from the `init.pp` and the `configure.pp` manifests. However, the contract for `wso2base` remains the same, to avoid from breaking semver. 