### PR TITLE
Add startup_script_name and pid_file_path parameters

### DIFF
--- a/hieradata/dev/wso2/common.yaml
+++ b/hieradata/dev/wso2/common.yaml
@@ -39,6 +39,9 @@ wso2::service_template: wso2base/wso2service.erb
 # Server startup script name
 wso2::startup_script_name: wso2server.sh
 
+# Process id file path
+wso2::pid_file_path: wso2carbon.pid
+
 # Start WSO2 Server Service automatically
 wso2::autostart_service: true
 

--- a/hieradata/dev/wso2/common.yaml
+++ b/hieradata/dev/wso2/common.yaml
@@ -33,8 +33,11 @@ wso2::hosts_mapping:
 wso2::ipaddress: "%{::ipaddress}"
 wso2::fqdn: "%{::fqdn}"
 
-# System service name
+# System service template
 wso2::service_template: wso2base/wso2service.erb
+
+# Server startup script name
+wso2::startup_script_name: wso2server.sh
 
 # Start WSO2 Server Service automatically
 wso2::autostart_service: true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,8 @@ class wso2base::params {
 
     # server startup script name
     $startup_script_name      = hiera('wso2::startup_script_name')
+    # process id file path
+    $pid_file_path            = hiera('wso2::pid_file_path')
     # whether we automatically start wso2service or not
     $autostart_service        = hiera('wso2::autostart_service')
     # java properties

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,8 @@ class wso2base::params {
   # use_hieradata facter flags whether parameter lookup should be done via Hiera
   if $::use_hieradata == 'true' {
 
+    # server startup script name
+    $startup_script_name      = hiera('wso2::startup_script_name')
     # whether we automatically start wso2service or not
     $autostart_service        = hiera('wso2::autostart_service')
     # java properties
@@ -31,9 +33,9 @@ class wso2base::params {
   } else {
 
     # whether we automatically start wso2service or not
-    $autostart_service        = 'true'
+    $autostart_service        = true
     # java properties
-    $install_java             = 'true'
+    $install_java             = true
     $java_install_dir         = '/mnt/jdk-8u131'
     $java_source_file         = 'jdk-8u131-linux-x64.tar.gz'
     $java_user                = 'wso2user'

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -33,6 +33,7 @@ class wso2base::system {
   $java_prefs_system_root = $wso2base::java_prefs_system_root
   $java_prefs_user_root   = $wso2base::java_prefs_user_root
   $startup_script_name    = $wso2base::startup_script_name
+  $pid_file_path          = $wso2base::pid_file_path
 
   # Install system packages
   package { $packages:

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -32,6 +32,7 @@ class wso2base::system {
   $java_home              = $wso2base::java_home
   $java_prefs_system_root = $wso2base::java_prefs_system_root
   $java_prefs_user_root   = $wso2base::java_prefs_user_root
+  $startup_script_name    = $wso2base::startup_script_name
 
   # Install system packages
   package { $packages:

--- a/templates/wso2service.erb
+++ b/templates/wso2service.erb
@@ -45,7 +45,7 @@ PRODUCT_CODE="<%= @service_name %>"
 JAVA_HOME="<%= @java_home %>"
 CARBON_HOME="<%= @carbon_home %>"
 LOCK_FILE="${CARBON_HOME}/wso2carbon.lck"
-PID_FILE="${CARBON_HOME}/wso2carbon.pid"
+PID_FILE="${CARBON_HOME}/<%= @pid_file_path %>"
 CMD="${CARBON_HOME}/bin/<%= @startup_script_name %>"
 
 SERVICE_RUNNING=0

--- a/templates/wso2service.erb
+++ b/templates/wso2service.erb
@@ -46,7 +46,7 @@ JAVA_HOME="<%= @java_home %>"
 CARBON_HOME="<%= @carbon_home %>"
 LOCK_FILE="${CARBON_HOME}/wso2carbon.lck"
 PID_FILE="${CARBON_HOME}/wso2carbon.pid"
-CMD="${CARBON_HOME}/bin/wso2server.sh"
+CMD="${CARBON_HOME}/bin/<%= @startup_script_name %>"
 
 SERVICE_RUNNING=0
 SERVICE_STOPPED=3


### PR DESCRIPTION
This pull request has parameterized server startup script name and process id file path defined in the system service. This is required for IOT and EI products.